### PR TITLE
Kullanıcı ayarlarının okunmama problemi giderildi.

### DIFF
--- a/MainForm.Designer.cs
+++ b/MainForm.Designer.cs
@@ -272,6 +272,7 @@
             this.Controls.Add(this.startButton);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            this.MaximizeBox = false;
             this.Name = "MainForm";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "cinali - Internet indirme aracı";

--- a/MainForm.cs
+++ b/MainForm.cs
@@ -47,6 +47,8 @@ namespace cinali
 
         Dictionary<Process, string> processList;
 
+        bool isStartUp = true;
+
         public MainForm()
         {
             InitializeComponent();
@@ -74,15 +76,12 @@ namespace cinali
         /// </summary>
         private void readSettings()
         {
-            bool tempNoLimitProperty; 
-
             settings = new Settings();
             settings.ReadFromRegistry();
-            tempNoLimitProperty = settings.NoLimit; 
             sitesTextBox.Lines = settings.Sites;
             outputFolderTextBox.Text = settings.OutputFolder;
-            limitTextBox.Text = settings.NoLimit ? String.Empty : settings.SpeedLimit.ToString();
-            noLimitCheckBox.Checked = tempNoLimitProperty;
+            noLimitCheckBox.Checked = settings.NoLimit;
+            limitTextBox.Text = settings.SpeedLimit.ToString();
             limitPanel.Enabled = !settings.NoLimit;
             runAtStartupCheckBox.Checked = settings.RunAtStartup;
 
@@ -118,7 +117,7 @@ namespace cinali
             stopButton.Enabled = true;
             processList = new Dictionary<Process, string>();
 
-            if (settings.SpeedLimit > 0)
+            if (!settings.NoLimit)
             {
                 perProcessLimit = settings.SpeedLimit / siteNames.Length;
                 if (perProcessLimit < 1)
@@ -260,9 +259,15 @@ namespace cinali
 
         private void updateSpeedLimit()
         {
+            if (isStartUp)
+            {
+                isStartUp = false;
+                return;
+            }
+
             if (noLimitCheckBox.Checked)
             {
-                settings.SpeedLimit = 0;
+                settings.NoLimit = noLimitCheckBox.Checked;
             }
             else
             {
@@ -270,6 +275,7 @@ namespace cinali
                 if (int.TryParse(limitTextBox.Text, out value))
                 {
                     settings.SpeedLimit = value;
+                    settings.NoLimit = noLimitCheckBox.Checked;
                 }
             }
         }

--- a/MainForm.cs
+++ b/MainForm.cs
@@ -74,11 +74,15 @@ namespace cinali
         /// </summary>
         private void readSettings()
         {
+            bool tempNoLimitProperty; 
+
             settings = new Settings();
+            settings.ReadFromRegistry();
+            tempNoLimitProperty = settings.NoLimit; 
             sitesTextBox.Lines = settings.Sites;
             outputFolderTextBox.Text = settings.OutputFolder;
-            noLimitCheckBox.Checked = settings.NoLimit;
             limitTextBox.Text = settings.NoLimit ? String.Empty : settings.SpeedLimit.ToString();
+            noLimitCheckBox.Checked = tempNoLimitProperty;
             limitPanel.Enabled = !settings.NoLimit;
             runAtStartupCheckBox.Checked = settings.RunAtStartup;
 

--- a/MainForm.cs
+++ b/MainForm.cs
@@ -47,6 +47,8 @@ namespace cinali
 
         Dictionary<Process, string> processList;
 
+        bool isStartup = true;
+
         public MainForm()
         {
             InitializeComponent();
@@ -74,15 +76,12 @@ namespace cinali
         /// </summary>
         private void readSettings()
         {
-            bool tempNoLimitProperty; 
-
             settings = new Settings();
             settings.ReadFromRegistry();
-            tempNoLimitProperty = settings.NoLimit; 
             sitesTextBox.Lines = settings.Sites;
             outputFolderTextBox.Text = settings.OutputFolder;
-            limitTextBox.Text = settings.NoLimit ? String.Empty : settings.SpeedLimit.ToString();
-            noLimitCheckBox.Checked = tempNoLimitProperty;
+            noLimitCheckBox.Checked = settings.NoLimit;
+            limitTextBox.Text = settings.SpeedLimit.ToString();
             limitPanel.Enabled = !settings.NoLimit;
             runAtStartupCheckBox.Checked = settings.RunAtStartup;
 
@@ -118,7 +117,7 @@ namespace cinali
             stopButton.Enabled = true;
             processList = new Dictionary<Process, string>();
 
-            if (settings.SpeedLimit > 0)
+            if (!settings.NoLimit)
             {
                 perProcessLimit = settings.SpeedLimit / siteNames.Length;
                 if (perProcessLimit < 1)
@@ -260,9 +259,15 @@ namespace cinali
 
         private void updateSpeedLimit()
         {
+            if (isStartup)
+            {
+                isStartup = false;
+                return;
+            }
+
             if (noLimitCheckBox.Checked)
             {
-                settings.SpeedLimit = 0;
+                settings.NoLimit = noLimitCheckBox.Checked;
             }
             else
             {
@@ -270,6 +275,7 @@ namespace cinali
                 if (int.TryParse(limitTextBox.Text, out value))
                 {
                     settings.SpeedLimit = value;
+                    settings.NoLimit = noLimitCheckBox.Checked;
                 }
             }
         }

--- a/MainForm.cs
+++ b/MainForm.cs
@@ -47,11 +47,7 @@ namespace cinali
 
         Dictionary<Process, string> processList;
 
-<<<<<<< HEAD
         bool isStartup = true;
-=======
-        bool isStartUp = true;
->>>>>>> origin/master
 
         public MainForm()
         {
@@ -263,15 +259,9 @@ namespace cinali
 
         private void updateSpeedLimit()
         {
-<<<<<<< HEAD
             if (isStartup)
             {
                 isStartup = false;
-=======
-            if (isStartUp)
-            {
-                isStartUp = false;
->>>>>>> origin/master
                 return;
             }
 

--- a/Settings.cs
+++ b/Settings.cs
@@ -34,6 +34,7 @@ namespace cinali
         const string sitesKey = "Sites";
         const string outputFolderKey = "OutputFolder";
         const string speedLimitKey = "SpeedLimit";
+        const string noLimitKey = "NoLimit";
         const string runAtStartupKey = "RunAtStartup";
         const string runKey = "cinali";
 
@@ -42,12 +43,23 @@ namespace cinali
         };
         const string defaultOutputSubFolder = "cinali";
         const int defaultSpeedLimit = 16; // 16kbps default speed
+        const bool defaultNoLimit = false;
 
         public string[] Sites { get; set; }
         public string OutputFolder { get; set; }
         public int SpeedLimit { get; set; }
         public bool RunAtStartup { get; set; }
-        public bool NoLimit { get { return SpeedLimit == 0; } }
+        public bool NoLimit
+        {
+            get
+            {
+                return SpeedLimit == 0;
+            }
+            set
+            {
+                if (value) SpeedLimit = 0;
+            }
+        }
 
         public Settings()
         {
@@ -55,6 +67,7 @@ namespace cinali
             string desktopFolder = Environment.GetFolderPath(Environment.SpecialFolder.Desktop);
             OutputFolder = Path.Combine(desktopFolder, defaultOutputSubFolder);
             SpeedLimit = defaultSpeedLimit;
+            NoLimit = defaultNoLimit;
             RunAtStartup = true;
         }
 
@@ -70,7 +83,8 @@ namespace cinali
                 Sites = (string[])key.GetValue(sitesKey, Sites);
                 OutputFolder = (string)key.GetValue(outputFolderKey, OutputFolder);
                 SpeedLimit = (int)key.GetValue(speedLimitKey, SpeedLimit);
-                RunAtStartup = (bool)key.GetValue(runAtStartupKey, RunAtStartup);
+                NoLimit = Convert.ToBoolean(key.GetValue(noLimitKey, NoLimit));
+                RunAtStartup = Convert.ToBoolean(key.GetValue(runAtStartupKey, RunAtStartup));
             }
         }
 
@@ -81,6 +95,7 @@ namespace cinali
                 key.SetValue(sitesKey, Sites);
                 key.SetValue(outputFolderKey, OutputFolder);
                 key.SetValue(speedLimitKey, SpeedLimit);
+                key.SetValue(noLimitKey, NoLimit);
                 key.SetValue(runAtStartupKey, RunAtStartup);
             }
 

--- a/Settings.cs
+++ b/Settings.cs
@@ -47,8 +47,7 @@ namespace cinali
 
         public string[] Sites { get; set; }
         public string OutputFolder { get; set; }
-        private int speedLimit;
-        public int SpeedLimit { get { return speedLimit; } set { speedLimit = value; } }
+        public int SpeedLimit { get; set; }
         public bool RunAtStartup { get; set; }
         public bool NoLimit { get; set; }
 

--- a/Settings.cs
+++ b/Settings.cs
@@ -47,22 +47,13 @@ namespace cinali
 
         public string[] Sites { get; set; }
         public string OutputFolder { get; set; }
-        public int SpeedLimit { get; set; }
+        private int speedLimit;
+        public int SpeedLimit { get { return speedLimit; } set { speedLimit = value; } }
         public bool RunAtStartup { get; set; }
-        public bool NoLimit
-        {
-            get
-            {
-                return SpeedLimit == 0;
-            }
-            set
-            {
-                if (value) SpeedLimit = 0;
-            }
-        }
+        public bool NoLimit { get; set; }
 
         public Settings()
-        {
+        { 
             Sites = defaultSites;
             string desktopFolder = Environment.GetFolderPath(Environment.SpecialFolder.Desktop);
             OutputFolder = Path.Combine(desktopFolder, defaultOutputSubFolder);


### PR DESCRIPTION
'Settings' sınıfının 'ReadFromRegistry()' fonksiyonunun çağrılmamasından kaynaklanan bir problem giderildi ve 'Settings' sınıfına 'NoLimitCheckBox' nesnesinin değerinin kayıt defterine eklenmesi sağlandı.

Not: Program açılışında ayarların okunup nesnelere atanması sırasında nesnelerin 'changed' tetikleyicilerinin çağırdığı 'updateSpeedLimit()' fonksiyonu 'Settings' sınıfındaki 'NoLimit' ve 'SpeedLimit' özelliklerine müdahele ediyor bu da ayarların yanlış ayarlanmasına neden oluyordu. Bu nedenle 'tempNoLimitProperty' isminde değişken eklenerek bu problem giderildi.